### PR TITLE
Add BetterKB combat module

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -178,6 +178,8 @@ object ModuleManager : Listenable, Collection<Module> by MODULE_REGISTRY {
             Rotations,
             SafeWalk,
             Scaffold,
+            BetterVelocity,
+            BetterKB,
             ServerCrasher,
             SkinDerp,
             SlimeJump,

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/BetterKB.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/BetterKB.kt
@@ -1,0 +1,95 @@
+/*
+ * LiquidBounce Hacked Client
+ * A free open source mixin-based injection hacked client for Minecraft using Minecraft Forge.
+ * https://github.com/CCBlueX/LiquidBounce/
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat
+
+import net.ccbluex.liquidbounce.config.*
+import net.ccbluex.liquidbounce.event.PacketEvent
+import net.ccbluex.liquidbounce.event.UpdateEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.utils.client.ClientUtils
+import net.minecraft.entity.Entity
+import net.minecraft.network.play.client.C02PacketUseEntity
+import net.minecraft.network.play.client.C02PacketUseEntity.Action.ATTACK
+import net.minecraft.network.play.client.C0BPacketEntityAction
+import net.minecraft.network.play.client.C0BPacketEntityAction.Action.START_SPRINTING
+import net.minecraft.network.play.client.C0BPacketEntityAction.Action.STOP_SPRINTING
+import net.minecraft.network.play.server.S29PacketSoundEffect
+
+object BetterKB : Module("BetterKB", Category.COMBAT) {
+
+    private val gticks by int("Ticks", 1, 0..20)
+    private val debug by boolean("Debug", false)
+    private val sprint by boolean("ShowSprint", false)
+
+    private var ticks = -1
+    private var isSprinting = false
+    private var blockInput = false
+    private var lastAttackedEntity: Entity? = null
+    private var lastAttackTime = 0L
+
+    override fun onToggle(state: Boolean) {
+        blockInput = false
+        ticks = -1
+    }
+
+    val onUpdate = handler<UpdateEvent> {
+        if (ticks == -1) return@handler
+
+        if (++ticks >= gticks) {
+            ticks = -1
+            blockInput = false
+        }
+    }
+
+    val onPacket = handler<PacketEvent> { event ->
+        val packet = event.packet
+        when (packet) {
+            is C0BPacketEntityAction -> when (packet.action) {
+                START_SPRINTING -> {
+                    if (sprint) {
+                        ClientUtils.displayChatMessage("started sprinting")
+                    }
+                    isSprinting = true
+                }
+                STOP_SPRINTING -> {
+                    if (sprint) {
+                        ClientUtils.displayChatMessage("stopped sprinting")
+                    }
+                    isSprinting = false
+                }
+                else -> {}
+            }
+            is S29PacketSoundEffect -> {
+                if (packet.soundName == "game.player.hurt") {
+                    val entity = lastAttackedEntity
+                    val distance = entity?.getDistance(packet.x, packet.y, packet.z)?.toDouble()
+                    if (distance != null && packet.volume == 1.0f && isSprinting &&
+                        System.currentTimeMillis() - lastAttackTime < 1000L && distance < 3.0
+                    ) {
+                        if (debug) {
+                            val name = entity.name
+                            ClientUtils.displayChatMessage("attacked $name distance: %.1f".format(distance))
+                        }
+                        lastAttackTime = 0L
+                        blockInput = true
+                        ticks = 0
+                    }
+                }
+            }
+            is C02PacketUseEntity -> {
+                if (packet.action == ATTACK) {
+                    lastAttackTime = System.currentTimeMillis()
+                    lastAttackedEntity = packet.getEntityFromWorld(mc.theWorld)
+                }
+            }
+        }
+    }
+
+    fun shouldBlockInput() = handleEvents() && blockInput
+}
+

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/client/MixinMovementInputFromOptions.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/client/MixinMovementInputFromOptions.java
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.injection.forge.mixins.client;
 
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.MovementInputEvent;
+import net.ccbluex.liquidbounce.features.module.modules.combat.BetterKB;
 import net.ccbluex.liquidbounce.features.module.modules.combat.SuperKnockback;
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffolds.Scaffold;
 import net.minecraft.util.MovementInput;
@@ -22,15 +23,18 @@ public class MixinMovementInputFromOptions extends MixinMovementInput {
     @Inject(method = "updatePlayerMoveState", at = @At(value = "FIELD", target = "Lnet/minecraft/util/MovementInputFromOptions;jump:Z"))
     private void hookSuperKnockbackInputBlock(CallbackInfo ci) {
         SuperKnockback module = SuperKnockback.INSTANCE;
-
         if (module.shouldBlockInput()) {
             if (module.getOnlyMove()) {
                 this.moveForward = 0f;
-
                 if (!module.getOnlyMoveForward()) {
                     this.moveStrafe = 0f;
                 }
             }
+        }
+
+        if (BetterKB.INSTANCE.shouldBlockInput()) {
+            this.moveForward = 0f;
+            this.moveStrafe = 0f;
         }
 
         Scaffold.INSTANCE.handleMovementOptions(((MovementInput) (Object) this));


### PR DESCRIPTION
## Summary
- restore BetterKB knockback module in Kotlin with configurable ticks, sprint and debug options
- integrate BetterKB input blocking into movement mixin

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a903ddd8348330be4840e4c59bc277